### PR TITLE
Handle response with no content-type header

### DIFF
--- a/messages_ui/middleware.py
+++ b/messages_ui/middleware.py
@@ -34,7 +34,7 @@ class AjaxMessagesMiddleware(object):
             not getattr(response, 'no_messages', False)
             )
         if handle_response:
-            content_type = response['content-type'].split(";")[0]
+            content_type = response.get('content-type', 'None').split(";")[0]
 
             content = response.content.decode('utf-8')
 


### PR DESCRIPTION
Hi, 
I am a developer for the MozTrap project. When we use this middleware with TastyPie, the DELETE request will cause a 500 server error. 

The DELETE request should return 204 No Content, which should not have a `content-type` in the response, so I use `get` to handle this situation, otherwise it will throw a `KeyError`. 

Thanks!