### PR TITLE
Update middleware.py to update the content length

### DIFF
--- a/messages_ui/middleware.py
+++ b/messages_ui/middleware.py
@@ -53,4 +53,5 @@ class AjaxMessagesMiddleware(object):
 
             response.content = json.dumps(data)
             response["content-type"] = "application/json"
+            response["content-length"] = len(response.content)
         return response


### PR DESCRIPTION
If you don't update the content length then jQuery doesn't seem to understand the data, it's a simple one line addition to update the content length header before returning the response.
